### PR TITLE
Bug fix initial item incorrect

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -123,7 +123,7 @@ class _CarouselSliderState extends State<CarouselSlider> with TickerProviderStat
         controller: widget.pageController,
         reverse: widget.reverse,
         itemBuilder: (BuildContext context, int i) {
-          final int index = _getRealIndex(i, 1000, widget.items.length);
+          final int index = _getRealIndex(i, widget.realPage, widget.items.length);
 
           return new AnimatedBuilder(
             animation: widget.pageController,


### PR DESCRIPTION
Fix the issue that passing hard coded `1000` inside `itemBuilder` function leads to incorrect initial item.