### PR TITLE
Add toggle item loop feature

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -37,3 +37,12 @@ Refactored ambiguous property names and deprecated the old ones.
 Updated example project displaying the new feature and refactored the code to follow flutters style guidelines.
 
 Updated .readme
+
+# 1.2.0
+
+Introducing two new features,
+Vertical scroll and enable/disable infinite scroll .
+
+Pass an `Axis` as the `scrollDirection` argument to specify direction.  
+Use `enableInfiniteScroll` to toggle between finite and infinite scroll mode.
+When `enableInfiniteScroll` is set to `false` the carousel will not scroll past the first or last item.

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ A carousel slider widget, support infinite scroll and custom child widget, with 
 
 ## Installation
 
-Add `carousel_slider: ^1.1.0` in your `pubspec.yaml` dependencies. And import it:
+Add `carousel_slider: ^1.2.0` in your `pubspec.yaml` dependencies. And import it:
 
 ```dart
 import 'package:carousel_slider/carousel_slider.dart';
@@ -44,6 +44,7 @@ CarouselSlider(
    aspectRatio: 16/9,
    viewportFraction: 0.8,
    initialPage: 0,
+   enableInfiniteScroll: true,
    reverse: false,
    autoPlay: true,
    autoPlayInterval: Duration(seconds: 3),
@@ -52,6 +53,7 @@ CarouselSlider(
    pauseAutoPlayOnTouch: Duration(seconds: 10),
    enlargeCenterPage: true,
    onPageChanged: callbackFunction,
+   scrollDirection: Axis.horizontal,
  )
 ```
 
@@ -158,6 +160,11 @@ if touched again during the time out the timer is reset to the duration passed t
 
 This feature can be useful if you want users to be able to interact with the screen and not have the pages continue sliding, forcing the user to repeatedly swipe back.
 One such example could be a commercial advertisement where the customers can react to something they like.
+
+### Can I disable the infinite loop mode?
+
+Yes. This was added by popular demand in patch `1.2.0`.  
+Just set the constructor argument `enableInfiniteScroll` to false.
 
 ##
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -218,6 +218,17 @@ class CarouselDemo extends StatelessWidget {
       ).toList(),
     );
 
+    //Non-looping manual Carousel
+    final CarouselSlider nonLoopingCarousel = CarouselSlider(
+      items: child,
+      enableInfiniteScroll: false,
+      autoPlay: false,
+      enlargeCenterPage: true,
+      viewportFraction: 0.9,
+      aspectRatio: 2.0,
+      );
+
+    //Vertical carousel
     final CarouselSlider verticalScrollCarousel = CarouselSlider(
       scrollDirection: Axis.vertical,
       aspectRatio: 2.0,
@@ -226,7 +237,7 @@ class CarouselDemo extends StatelessWidget {
       viewportFraction: 0.9,
       pauseAutoPlayOnTouch: Duration(seconds: 3),
       items: imgList.map(
-            (url) {
+        (url) {
           return Container(
             margin: EdgeInsets.all(5.0),
             child: ClipRRect(
@@ -282,6 +293,12 @@ class CarouselDemo extends StatelessWidget {
               child: Column(children: [
                 Text('Pause When Touched Carousel'),
                 touchDetectionDemo,
+              ])),
+          Padding(
+              padding: EdgeInsets.symmetric(vertical: 15.0),
+              child: Column(children: [
+                Text('No infinity scroll carousel'),
+                nonLoopingCarousel,
               ])),
           Padding(
               padding: EdgeInsets.symmetric(vertical: 15.0),

--- a/example/pubspec.lock
+++ b/example/pubspec.lock
@@ -85,7 +85,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.3"
   stack_trace:
     dependency: transitive
     description:
@@ -113,7 +113,7 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   test_api:
     dependency: transitive
     description:

--- a/pubspec.lock
+++ b/pubspec.lock
@@ -78,7 +78,7 @@ packages:
       name: source_span
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.4.1"
+    version: "1.5.3"
   stack_trace:
     dependency: transitive
     description:
@@ -106,7 +106,7 @@ packages:
       name: term_glyph
       url: "https://pub.dartlang.org"
     source: hosted
-    version: "1.0.1"
+    version: "1.1.0"
   test_api:
     dependency: transitive
     description:


### PR DESCRIPTION
By popular demand I created a simple bool, `loopItems`,
when set to false will reduce the item count to items.count.

This results in a static length page viewer that still retains
all the other benefits of this library (animations, buttons, autoplay etc...).

I also added comments to this and the vertical scroll feature i rebased against.
I realized now that it still have a PR open, but I added some info about it in the
Readme and change-log.

I suggest we add the features together and bump the version code to 1.2.0
(major.minor.patch) insteadof 1.2.0 and then 1.3.0 imminently after.