### PR TITLE
fix "setState() called after dispose()" in build() method

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -239,7 +239,9 @@ class _CarouselSliderState extends State<CarouselSlider> with TickerProviderStat
             if (widget.pageController.position.minScrollExtent == null ||
                 widget.pageController.position.maxScrollExtent == null) {
               Future.delayed(Duration(microseconds: 1), () {
-                setState(() {});
+	        if (this.mounted) {
+                  setState(() {});
+		}
               });
               return Container();
             }


### PR DESCRIPTION
In my flutter project, I had to use carousel inside a ListView builder.

When I was scrolling my ListView, here is the error I had : 

E/flutter (20376): [ERROR:flutter/lib/ui/ui_dart_state.cc(148)] Unhandled Exception: setState() called after dispose(): _CarouselSliderState#2397a(lifecycle state: defunct, not mounted)
E/flutter (20376): This error happens if you call setState() on a State object for a widget that no longer appears in the widget tree (e.g., whose parent widget no longer includes the widget in its build). This error can occur when code calls setState() from a timer or an animation callback.
E/flutter (20376): The preferred solution is to cancel the timer or stop listening to the animation in the dispose() callback. Another solution is to check the "mounted" property of this object before calling setState() to ensure the object is still in the tree.
E/flutter (20376): This error might indicate a memory leak if setState() is being called because another object is retaining a reference to this State object after it has been removed from the tree. To avoid memory leaks, consider breaking the reference to this object during dispose().

Here is a fix for this !

Thanks for your attention.