### PR TITLE
Determine if a carousel change was due timer or manual manipulation

### DIFF
--- a/pubspec.yaml
+++ b/pubspec.yaml
@@ -2,7 +2,7 @@ name: carousel_slider
 description: A carousel slider widget, support infinite scroll and custom child widget.
 author: serenader <xyslive@gmail.com>
 homepage: https://github.com/serenader2014/flutter_carousel_slider
-version: 1.3.1
+version: 1.3.1+1
 
 environment:
   sdk: ">=2.0.0-dev.28.0 <3.0.0"


### PR DESCRIPTION
This relates to the issue 69, to allow the callback to onPageChanged to determine if the reason was due to the timer (automatic) or the user (manual) changing the page.