### PR TITLE
Update CarouselSlider onPageChanged param

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,7 +134,7 @@ class _CarouselWithIndicatorState extends State<CarouselWithIndicator> {
           items: child,
           autoPlay: true,
           aspectRatio: 2.0,
-          onPageChangedCallback: (index) {
+          onPageChanged: (index) {
             setState(() {
               _current = index;
             });


### PR DESCRIPTION
In the example CarouselWithIndicator, the CarouselSlider widget had an incorrect param name.