### PR TITLE
Replaced SizedBox with Transform.scale

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -215,17 +215,20 @@ class CarouselSliderState extends State<CarouselSlider> with TickerProviderState
 
             if (widget.options.scrollDirection == Axis.horizontal) {
               return Center(
-                child: SizedBox(
-                  height: distortionValue * height,
-                  child: child,
-                ),
-              );
+                child: Transform.scale(
+                        scale: distortionValue,
+                        child: Container(height: height, child: child)
+                       )
+                );
             } else {
               return Center(
-                child: SizedBox(
-                  width: distortionValue * MediaQuery.of(context).size.width,
-                  child: child,
-                ),
+                child: Transform.scale(
+                  scale: distortionValue, 
+                  child: Container(
+                      width: MediaQuery.of(context).size.width,
+                      child: child
+                  ),
+                )
               );
             }
           },


### PR DESCRIPTION
Replaced SizedBox with Transform.scale to increase flexibility, since this Transform.scale scales all the elements inside of a container. This opposed to SizedBox, which would only affect the size of the container itself, without changing the size of all the elements inside. This resulted in some weird visual behaviour, which is fixed with this PR.