### PR TITLE
Fixed AspectRatio

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -128,7 +128,7 @@ class CarouselSliderState extends State<CarouselSlider> with TickerProviderState
     if (widget.options.height != null) {
       wrapper = Container(height: widget.options.height, child: child);
     } else {
-      wrapper = AspectRatio(aspectRatio: widget.options.aspectRatio, child: child);
+      wrapper = AspectRatio(aspectRatio: (widget.options.aspectRatio / widget.options.viewportFraction), child: child);
     }
 
     Widget listenerWrapper = NotificationListener(
@@ -211,7 +211,7 @@ class CarouselSliderState extends State<CarouselSlider> with TickerProviderState
 
             final double height = widget.options.height ??
                 MediaQuery.of(context).size.width *
-                    (1 / widget.options.aspectRatio);
+                    (widget.options.viewportFraction / widget.options.aspectRatio);
 
             if (widget.options.scrollDirection == Axis.horizontal) {
               return Center(


### PR DESCRIPTION
Hi,

I think there might be an error when calculating the aspect ratio.

When testing the carousel with an aspect ratio of 1 I didn't have the expected result (ratio of the container not 1:1). I think it's because it doesn't take in count the viewportFraction attribute.

I updated the code to adapt the aspectRatio in function of the viewportFraction.

Expected result:
<img width="402" alt="good_ratio" src="https://user-images.githubusercontent.com/55256645/80771208-888a0500-8b07-11ea-9fd9-e71e382b637b.png">

Result:
<img width="402" alt="bad_ratio" src="https://user-images.githubusercontent.com/55256645/80771213-8d4eb900-8b07-11ea-845b-5b25b98e6422.png">
