### PR TITLE
Add option for disable page snapping for the carousel

### DIFF
--- a/lib/carousel_options.dart
+++ b/lib/carousel_options.dart
@@ -83,6 +83,11 @@ class CarouselOptions {
   /// Defaults to matching platform conventions.
   final ScrollPhysics scrollPhysics;
 
+  /// Set to false to disable page snapping, useful for custom scroll behavior.
+  ///
+  /// Default to `true`.
+  final bool pageSnapping;
+
   /// If `true`, the auto play function will be paused when user is interacting with
   /// the carousel, and will be resumed when user finish interacting.
   /// Default to `true`.
@@ -125,6 +130,7 @@ class CarouselOptions {
     this.onPageChanged,
     this.onScrolled,
     this.scrollPhysics,
+    this.pageSnapping = true,
     this.scrollDirection: Axis.horizontal,
     this.pauseAutoPlayOnTouch: true,
     this.pauseAutoPlayOnManualNavigate: true,

--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -231,6 +231,7 @@ class CarouselSliderState extends State<CarouselSlider>
     return getGestureWrapper(PageView.builder(
       physics: widget.options.scrollPhysics,
       scrollDirection: widget.options.scrollDirection,
+      pageSnapping: widget.options.pageSnapping,
       controller: carouselState.pageController,
       reverse: widget.options.reverse,
       itemCount: widget.options.enableInfiniteScroll ? null : widget.itemCount,


### PR DESCRIPTION
Add the option for disable the page snapping in the carousel. This is useful when adding your own ScrollPhysics, because only when page snapping is disabled it's possible to overwrite the whole scroll physics. Otherwise the custom physics only apply to to the PageScrollPhysics.

MR for this issue: https://github.com/serenader2014/flutter_carousel_slider/issues/158