### PR TITLE
fix carousel_controller.dart

### DIFF
--- a/lib/carousel_controller.dart
+++ b/lib/carousel_controller.dart
@@ -58,8 +58,8 @@ class CarouselControllerImpl implements CarouselController {
     if (isNeedResetTimer) {
       _state.onResetTimer();
     }
+     _setModeController();
     await _state.pageController.nextPage(duration: duration, curve: curve);
-    _setModeController();
     if (isNeedResetTimer) {
       _state.onResumeTimer();
     }


### PR DESCRIPTION
Fix nextPage method to match previousPage.  _setModeController must be called before ` await _state.pageController.nextPage(duration: duration, curve: curve);` or else CarouselPageChangedReason will default to `manual` instead of `controller`.