### PR TITLE
Double pointer down and up will cause a exception

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -330,9 +330,4 @@ class CarouselSliderState extends State<CarouselSlider>
   }
 }
 
-class _MultipleGestureRecognizer extends PanGestureRecognizer {
-  @override
-  void rejectGesture(int pointer) {
-    acceptGesture(pointer);
-  }
-}
+class _MultipleGestureRecognizer extends PanGestureRecognizer {}


### PR DESCRIPTION
I investigate this because @marcellocamara file an issue on Flutter https://github.com/flutter/flutter/issues/71331

There is no reason to override `rejectGesture` with `acceptGesture`, and we can't do this. This will destroy the architectural design of the flutter, and I review the original PR. I think this is more likely to be a typo, rather than intend doing this. Without this, all features work well.