### PR TITLE
docs: ItemBuilder should pass the third argument.

### DIFF
--- a/README.md
+++ b/README.md
@@ -90,7 +90,7 @@ It can be used to build different child item widgets related to content or by it
 
 CarouselSlider.builder(
   itemCount: 15,
-  itemBuilder: (BuildContext context, int itemIndex) =>
+  itemBuilder: (BuildContext context, int itemIndex, int pageViewIndex) =>
     Container(
       child: Text(itemIndex.toString()),
     ),


### PR DESCRIPTION
Without third argument (PageView index), `itemBuilder` generates an error:
```console
The argument type 'Widget Function(BuildContext, int)' can't be assigned to the parameter type 'Widget Function(BuildContext, int, int)'.dart(argument_type_not_assignable)
```