### PR TITLE
Fixing problem with timer after dispose widget

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -126,7 +126,7 @@ class CarouselSliderState extends State<CarouselSlider>
     return widget.options.autoPlay
         ? Timer.periodic(widget.options.autoPlayInterval, (_) {
             // avoid problems to access context after state dispose
-            if (!mounted) {
+            if (!mounted || ModalRoute.of(context)?.isCurrent != true) {
               return;
             }
 

--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -125,6 +125,11 @@ class CarouselSliderState extends State<CarouselSlider>
   Timer? getTimer() {
     return widget.options.autoPlay
         ? Timer.periodic(widget.options.autoPlayInterval, (_) {
+            // avoid problems to access context after state dispose
+            if (!mounted) {
+              return;
+            }
+
             final route = ModalRoute.of(context);
             if (route?.isCurrent == false) {
               return;


### PR DESCRIPTION
The line:

 `final route = ModalRoute.of(context);` 

was throw some errors when using slider carousel in a page inside a IndexedStack.

Adding if mounted before use context solve the problem.