### PR TITLE
New option to animate to closest page

### DIFF
--- a/lib/carousel_controller.dart
+++ b/lib/carousel_controller.dart
@@ -110,9 +110,17 @@ class CarouselControllerImpl implements CarouselController {
     }
     final index = getRealIndex(_state!.pageController!.page!.toInt(),
         _state!.realPage - _state!.initialPage, _state!.itemCount);
+    int smallestMovement = page - index;
+    if (_state!.options.enableInfiniteScroll &&
+        _state!.itemCount != null &&
+        _state!.options.animateToClosest) {
+      if ((page - index).abs() > (page + _state!.itemCount! - index).abs()) {
+        smallestMovement = page + _state!.itemCount! - index;
+      }
+    }
     _setModeController();
     await _state!.pageController!.animateToPage(
-        _state!.pageController!.page!.toInt() + page - index,
+        _state!.pageController!.page!.toInt() + smallestMovement,
         duration: duration!,
         curve: curve!);
     if (isNeedResetTimer) {

--- a/lib/carousel_controller.dart
+++ b/lib/carousel_controller.dart
@@ -116,6 +116,8 @@ class CarouselControllerImpl implements CarouselController {
         _state!.options.animateToClosest) {
       if ((page - index).abs() > (page + _state!.itemCount! - index).abs()) {
         smallestMovement = page + _state!.itemCount! - index;
+      } else if ((page - index).abs() > (page - _state!.itemCount! - index).abs()) {
+        smallestMovement = page - _state!.itemCount! - index;
       }
     }
     _setModeController();

--- a/lib/carousel_options.dart
+++ b/lib/carousel_options.dart
@@ -28,6 +28,11 @@ class CarouselOptions {
   ///Defaults to true, i.e. infinite loop.
   final bool enableInfiniteScroll;
 
+  ///Determines if carousel should loop to the closest occurence of requested page.
+  ///
+  ///Defaults to true.
+  final bool animateToClosest;
+
   /// Reverse the order of items if set to true.
   ///
   /// Defaults to false.
@@ -130,6 +135,7 @@ class CarouselOptions {
     this.viewportFraction: 0.8,
     this.initialPage: 0,
     this.enableInfiniteScroll: true,
+    this.animateToClosest: true,
     this.reverse: false,
     this.autoPlay: false,
     this.autoPlayInterval: const Duration(seconds: 4),


### PR DESCRIPTION
Added an option to the CarouselOption to animate to the nearest requested page when infinite scroll is enabled.

When calling the `animateToPage` function of CarouselControllerImpl (CarouselController), the closest occurrence of the requested page is chosen. 

If the animateToClosest option is set to false, the default behavior is kept.
Only works if itemCount is set.