### PR TITLE
fix: clear timer if widget was unmounted

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -125,6 +125,11 @@ class CarouselSliderState extends State<CarouselSlider>
   Timer? getTimer() {
     return widget.options.autoPlay
         ? Timer.periodic(widget.options.autoPlayInterval, (_) {
+            if(!mounted){
+              clearTimer();
+              return;
+            }
+
             final route = ModalRoute.of(context);
             if (route?.isCurrent == false) {
               return;


### PR DESCRIPTION
In more complex application with multiple tabs and custom autoplay running around, there might be a scenario, that page gets disposed (tab is switched), yet timer it still being run. Once timer hits - `widget is not mounted` (l133)  thus throwing
```
[ERROR:flutter/runtime/dart_vm_initializer.cc(41)] Unhandled Exception: This widget has been unmounted, so the State no longer has a context (and should be considered defunct).
Consider canceling any active work during "dispose" or using the "mounted" getter to determine if the State is still active.
#0      State.context.<anonymous closure> (package:flutter/src/widgets/framework.dart:935:9)
#1      State.context (package:flutter/src/widgets/framework.dart:941:6)
#2      CarouselSliderState.getTimer.<anonymous closure> (package:carousel_slider/carousel_slider.dart:128:41)
#3      _Timer._runTimers (dart:isolate-patch/timer_impl.dart:398:19)
#4      _Timer._handleMessage (dart:isolate-patch/timer_impl.dart:429:5)
#5      _RawReceivePortImpl._handleMessage (dart:isolate-patch/isolate_patch.dart:192:12)
```


Checking prior if widget is mounted fixes this issue.