### PR TITLE
handle null check operator in nextPage, previousPage

### DIFF
--- a/example/ios/Runner.xcodeproj/project.pbxproj
+++ b/example/ios/Runner.xcodeproj/project.pbxproj
@@ -3,7 +3,7 @@
 	archiveVersion = 1;
 	classes = {
 	};
-	objectVersion = 50;
+	objectVersion = 54;
 	objects = {
 
 /* Begin PBXBuildFile section */
@@ -171,10 +171,12 @@
 /* Begin PBXShellScriptBuildPhase section */
 		3B06AD1E1E4923F5004D2608 /* Thin Binary */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);
 			inputPaths = (
+				"${TARGET_BUILD_DIR}/${INFOPLIST_PATH}",
 			);
 			name = "Thin Binary";
 			outputPaths = (
@@ -185,6 +187,7 @@
 		};
 		9740EEB61CF901F6004384FC /* Run Script */ = {
 			isa = PBXShellScriptBuildPhase;
+			alwaysOutOfDate = 1;
 			buildActionMask = 2147483647;
 			files = (
 			);

--- a/example/ios/Runner/Info.plist
+++ b/example/ios/Runner/Info.plist
@@ -43,5 +43,7 @@
 	<false/>
 	<key>CADisableMinimumFrameDurationOnPhone</key>
 	<true/>
+	<key>UIApplicationSupportsIndirectInputEvents</key>
+	<true/>
 </dict>
 </plist>

--- a/lib/carousel_controller.dart
+++ b/lib/carousel_controller.dart
@@ -11,9 +11,9 @@ abstract class CarouselController {
 
   Future<Null> get onReady;
 
-  Future<void> nextPage({Duration? duration, Curve? curve});
+  Future<void> nextPage({Duration duration, Curve curve});
 
-  Future<void> previousPage({Duration? duration, Curve? curve});
+  Future<void> previousPage({Duration duration, Curve curve});
 
   void jumpToPage(int page);
 
@@ -52,16 +52,16 @@ class CarouselControllerImpl implements CarouselController {
   /// The animation lasts for the given duration and follows the given curve.
   /// The returned [Future] resolves when the animation completes.
   Future<void> nextPage(
-      {Duration? duration = const Duration(milliseconds: 300),
-      Curve? curve = Curves.linear}) async {
-    final bool isNeedResetTimer = _state!.options.pauseAutoPlayOnManualNavigate;
+      {Duration duration = const Duration(milliseconds: 300),
+        Curve curve = Curves.linear}) async {
+    final bool isNeedResetTimer = _state?.options.pauseAutoPlayOnManualNavigate ?? false;
     if (isNeedResetTimer) {
-      _state!.onResetTimer();
+      _state?.onResetTimer();
     }
     _setModeController();
-    await _state!.pageController!.nextPage(duration: duration!, curve: curve!);
+    await _state?.pageController?.nextPage(duration: duration, curve: curve);
     if (isNeedResetTimer) {
-      _state!.onResumeTimer();
+      _state?.onResumeTimer();
     }
   }
 
@@ -70,17 +70,16 @@ class CarouselControllerImpl implements CarouselController {
   /// The animation lasts for the given duration and follows the given curve.
   /// The returned [Future] resolves when the animation completes.
   Future<void> previousPage(
-      {Duration? duration = const Duration(milliseconds: 300),
-      Curve? curve = Curves.linear}) async {
-    final bool isNeedResetTimer = _state!.options.pauseAutoPlayOnManualNavigate;
+      {Duration duration = const Duration(milliseconds: 300),
+        Curve curve = Curves.linear}) async {
+    final bool isNeedResetTimer = _state?.options.pauseAutoPlayOnManualNavigate ?? false;
     if (isNeedResetTimer) {
-      _state!.onResetTimer();
+      _state?.onResetTimer();
     }
     _setModeController();
-    await _state!.pageController!
-        .previousPage(duration: duration!, curve: curve!);
+    await _state?.pageController?.previousPage(duration: duration, curve: curve);
     if (isNeedResetTimer) {
-      _state!.onResumeTimer();
+      _state?.onResumeTimer();
     }
   }
 


### PR DESCRIPTION
i faced this bug in our release firebase crashlytics notify us with this 
```
CarouselControllerImpl.nextPage
FlutterError - Null check operator used on a null value 
```

so i handled this bug by replacing all null check operator with null aware operator