### PR TITLE
onEndScroll callback in carousel options

### DIFF
--- a/lib/carousel_options.dart
+++ b/lib/carousel_options.dart
@@ -77,6 +77,9 @@ class CarouselOptions {
   /// Called whenever the carousel is scrolled
   final ValueChanged<double?>? onScrolled;
 
+  /// Called whenever the carousel stops scrolling
+  final ValueChanged<int>? onEndScroll;
+
   /// How the carousel should respond to user input.
   ///
   /// For example, determines how the items continues to animate after the
@@ -148,6 +151,7 @@ class CarouselOptions {
     this.enlargeCenterPage = false,
     this.onPageChanged,
     this.onScrolled,
+    this.onEndScroll,
     this.scrollPhysics,
     this.pageSnapping = true,
     this.scrollDirection: Axis.horizontal,
@@ -178,6 +182,7 @@ class CarouselOptions {
           bool? enlargeCenterPage,
           Function(int index, CarouselPageChangedReason reason)? onPageChanged,
           ValueChanged<double?>? onScrolled,
+          ValueChanged<int>? onEndScroll,
           ScrollPhysics? scrollPhysics,
           bool? pageSnapping,
           Axis? scrollDirection,
@@ -205,6 +210,7 @@ class CarouselOptions {
         enlargeCenterPage: enlargeCenterPage ?? this.enlargeCenterPage,
         onPageChanged: onPageChanged ?? this.onPageChanged,
         onScrolled: onScrolled ?? this.onScrolled,
+        onEndScroll: onEndScroll ?? this.onEndScroll,
         scrollPhysics: scrollPhysics ?? this.scrollPhysics,
         pageSnapping: pageSnapping ?? this.pageSnapping,
         scrollDirection: scrollDirection ?? this.scrollDirection,

--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -202,6 +202,13 @@ class CarouselSliderState extends State<CarouselSlider>
               notification is ScrollUpdateNotification) {
             widget.options.onScrolled!(carouselState!.pageController!.page);
           }
+          if (notification is ScrollEndNotification) {
+            widget.options.onEndScroll
+                ?.call(getRealIndex(
+                carouselState!.pageController!.page!.toInt(),
+                carouselState!.realPage - carouselState!.initialPage,
+                carouselState!.itemCount));
+          }
           return false;
         },
         child: wrapper,
@@ -234,6 +241,13 @@ class CarouselSliderState extends State<CarouselSlider>
           if (widget.options.onScrolled != null &&
               notification is ScrollUpdateNotification) {
             widget.options.onScrolled!(carouselState!.pageController!.page);
+          }
+          if (notification is ScrollEndNotification) {
+            widget.options.onEndScroll
+                ?.call(getRealIndex(
+                carouselState!.pageController!.page!.toInt(),
+                carouselState!.realPage - carouselState!.initialPage,
+                carouselState!.itemCount));
           }
           return false;
         },


### PR DESCRIPTION
Adeed a onEndScroll callback to the carousel options. 
This functions returns the current page index when the scroll ends.