### PR TITLE
Fix an issue where the autoplay will be triggered while the user is interacting with it.

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -208,26 +208,16 @@ class CarouselSliderState extends State<CarouselSlider>
       );
     }
 
-    return RawGestureDetector(
+    return Listener(
       behavior: HitTestBehavior.opaque,
-      gestures: {
-        _MultipleGestureRecognizer:
-            GestureRecognizerFactoryWithHandlers<_MultipleGestureRecognizer>(
-                () => _MultipleGestureRecognizer(),
-                (_MultipleGestureRecognizer instance) {
-          instance.onStart = (_) {
-            onStart();
-          };
-          instance.onDown = (_) {
-            onPanDown();
-          };
-          instance.onEnd = (_) {
-            onPanUp();
-          };
-          instance.onCancel = () {
-            onPanUp();
-          };
-        }),
+      onPointerDown: (_) {
+        onPanDown();
+      },
+      onPointerCancel: (_) {
+        onPanUp();
+      },
+      onPointerUp: (_) {
+        onPanUp();
       },
       child: NotificationListener(
         onNotification: (Notification notification) {
@@ -272,10 +262,6 @@ class CarouselSliderState extends State<CarouselSlider>
     return Transform.scale(
         scale: scale!,
         child: Container(child: child, width: width, height: height));
-  }
-
-  void onStart() {
-    changeMode(CarouselPageChangedReason.manual);
   }
 
   void onPanDown() {
@@ -355,7 +341,7 @@ class CarouselSliderState extends State<CarouselSlider>
                 BuildContext storageContext = carouselState!
                     .pageController!.position.context.storageContext;
                 final double? previousSavedPosition =
-                    PageStorage.of(storageContext)?.readState(storageContext)
+                    PageStorage.of(storageContext).readState(storageContext)
                         as double?;
                 if (previousSavedPosition != null) {
                   itemOffset = previousSavedPosition - idx.toDouble();
@@ -394,5 +380,3 @@ class CarouselSliderState extends State<CarouselSlider>
     ));
   }
 }
-
-class _MultipleGestureRecognizer extends PanGestureRecognizer {}


### PR DESCRIPTION
For `PanGestureRecognizer` the `onEnd` function is called whenever the user drags their finger on the widget, replaced with a direct Listener to pointer events with `onPointerUp` that triggers when the user lifts their finger from the carousel.