### PR TITLE
fix compilation for flutter 3.24.0

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -1,5 +1,5 @@
 import 'package:carousel_slider/carousel_slider.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide CarouselController;
 
 final List<String> imgList = [
   'https://images.unsplash.com/photo-1520342868574-5fa3804e551c?ixlib=rb-0.3.5&ixid=eyJhcHBfaWQiOjEyMDd9&s=6ff92caffcdd63681a35134a6770ed3b&auto=format&fit=crop&w=1951&q=80',

--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 
 import 'package:carousel_slider/carousel_state.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide CarouselController;
 
 import 'carousel_controller.dart';
 import 'carousel_options.dart';


### PR DESCRIPTION
Flutter 3.24.0 introduced some naming conflicts with their `CarouselController`. This PR updates the package to hide that import.