### PR TITLE
chore: change controller name

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -255,7 +255,7 @@ class ManuallyControlledSlider extends StatefulWidget {
 }
 
 class _ManuallyControlledSliderState extends State<ManuallyControlledSlider> {
-  final CarouselController _controller = CarouselController();
+  final CarouselSliderController _controller = CarouselSliderController();
 
   @override
   void initState() {
@@ -408,7 +408,7 @@ class CarouselWithIndicatorDemo extends StatefulWidget {
 
 class _CarouselWithIndicatorState extends State<CarouselWithIndicatorDemo> {
   int _current = 0;
-  final CarouselController _controller = CarouselController();
+  final CarouselSliderController _controller = CarouselSliderController();
 
   @override
   Widget build(BuildContext context) {
@@ -515,7 +515,7 @@ class CarouselChangeReasonDemo extends StatefulWidget {
 
 class _CarouselChangeReasonDemoState extends State<CarouselChangeReasonDemo> {
   String reason = '';
-  final CarouselController _controller = CarouselController();
+  final CarouselSliderController _controller = CarouselSliderController();
 
   void onPageChange(int index, CarouselPageChangedReason changeReason) {
     setState(() {

--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -6,11 +6,11 @@ import 'package:carousel_slider/carousel_state.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
-import 'carousel_controller.dart';
+import 'carousel_slider_controller.dart';
 import 'carousel_options.dart';
 import 'utils.dart';
 
-export 'carousel_controller.dart';
+export 'carousel_slider_controller.dart';
 export 'carousel_options.dart';
 
 typedef Widget ExtendedIndexedWidgetBuilder(
@@ -31,7 +31,7 @@ class CarouselSlider extends StatefulWidget {
   final ExtendedIndexedWidgetBuilder? itemBuilder;
 
   /// A [MapController], used to control the map.
-  final CarouselControllerImpl _carouselController;
+  final CarouselSliderControllerImpl _carouselController;
 
   final int? itemCount;
 
@@ -39,13 +39,13 @@ class CarouselSlider extends StatefulWidget {
       {required this.items,
       required this.options,
       this.disableGesture,
-      CarouselController? carouselController,
+      CarouselSliderController? carouselController,
       Key? key})
       : itemBuilder = null,
         itemCount = items != null ? items.length : 0,
         _carouselController = carouselController != null
-            ? carouselController as CarouselControllerImpl
-            : CarouselController() as CarouselControllerImpl,
+            ? carouselController as CarouselSliderControllerImpl
+            : CarouselSliderController() as CarouselSliderControllerImpl,
         super(key: key);
 
   /// The on demand item builder constructor
@@ -54,12 +54,12 @@ class CarouselSlider extends StatefulWidget {
       required this.itemBuilder,
       required this.options,
       this.disableGesture,
-      CarouselController? carouselController,
+      CarouselSliderController? carouselController,
       Key? key})
       : items = null,
         _carouselController = carouselController != null
-            ? carouselController as CarouselControllerImpl
-            : CarouselController() as CarouselControllerImpl,
+            ? carouselController as CarouselSliderControllerImpl
+            : CarouselSliderController() as CarouselSliderControllerImpl,
         super(key: key);
 
   @override
@@ -68,7 +68,7 @@ class CarouselSlider extends StatefulWidget {
 
 class CarouselSliderState extends State<CarouselSlider>
     with TickerProviderStateMixin {
-  final CarouselControllerImpl carouselController;
+  final CarouselSliderControllerImpl carouselController;
   Timer? timer;
 
   CarouselOptions get options => widget.options;
@@ -355,7 +355,7 @@ class CarouselSliderState extends State<CarouselSlider>
                 BuildContext storageContext = carouselState!
                     .pageController!.position.context.storageContext;
                 final double? previousSavedPosition =
-                    PageStorage.of(storageContext)?.readState(storageContext)
+                    PageStorage.of(storageContext).readState(storageContext)
                         as double?;
                 if (previousSavedPosition != null) {
                   itemOffset = previousSavedPosition - idx.toDouble();

--- a/lib/carousel_slider_controller.dart
+++ b/lib/carousel_slider_controller.dart
@@ -6,7 +6,7 @@ import 'carousel_options.dart';
 import 'carousel_state.dart';
 import 'utils.dart';
 
-abstract class CarouselController {
+abstract class CarouselSliderController {
   bool get ready;
 
   Future<Null> get onReady;
@@ -23,10 +23,10 @@ abstract class CarouselController {
 
   void stopAutoPlay();
 
-  factory CarouselController() => CarouselControllerImpl();
+  factory CarouselSliderController() => CarouselSliderControllerImpl();
 }
 
-class CarouselControllerImpl implements CarouselController {
+class CarouselSliderControllerImpl implements CarouselSliderController {
   final Completer<Null> _readyCompleter = Completer<Null>();
 
   CarouselState? _state;


### PR DESCRIPTION
The new version of flutter contains a class with the same name [CarouselController](https://pub.dev/documentation/carousel_slider/latest/carousel_controller/CarouselController-class.html) . To fix dependencies сщтадшсе, I renamed the controller class 