### PR TITLE
fix: Rename CarouselController to CarouselSliderController

### DIFF
--- a/README.md
+++ b/README.md
@@ -100,11 +100,11 @@ CarouselSlider.builder(
 
 ## Carousel controller
 
-In order to manually control the pageview's position, you can create your own `CarouselController`, and pass it to `CarouselSlider`. Then you can use the `CarouselController` instance to manipulate the position.
+In order to manually control the pageview's position, you can create your own `CarouselSliderController`, and pass it to `CarouselSlider`. Then you can use the `CarouselSliderController` instance to manipulate the position.
 
 ```dart 
 class CarouselDemo extends StatelessWidget {
-  CarouselController buttonCarouselController = CarouselController();
+  CarouselSliderController buttonCarouselController = CarouselSliderController();
 
  @override
   Widget build(BuildContext context) => Column(
@@ -130,7 +130,7 @@ class CarouselDemo extends StatelessWidget {
 }
 ```
 
-### `CarouselController` methods
+### `CarouselSliderController` methods
 
 #### `.nextPage({Duration duration, Curve curve})`
 
@@ -170,7 +170,7 @@ Image carousel slider with custom indicator demo:
 
 ![indicator](screenshot/indicator.gif)
 
-Custom `CarouselController` and manually control the pageview position demo:
+Custom `CarouselSliderController` and manually control the pageview position demo:
 
 ![manual](screenshot/manually.gif)
 

--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -255,7 +255,7 @@ class ManuallyControlledSlider extends StatefulWidget {
 }
 
 class _ManuallyControlledSliderState extends State<ManuallyControlledSlider> {
-  final CarouselController _controller = CarouselController();
+  final CarouselSliderController _controller = CarouselSliderController();
 
   @override
   void initState() {
@@ -408,7 +408,7 @@ class CarouselWithIndicatorDemo extends StatefulWidget {
 
 class _CarouselWithIndicatorState extends State<CarouselWithIndicatorDemo> {
   int _current = 0;
-  final CarouselController _controller = CarouselController();
+  final CarouselSliderController _controller = CarouselSliderController();
 
   @override
   Widget build(BuildContext context) {
@@ -515,7 +515,7 @@ class CarouselChangeReasonDemo extends StatefulWidget {
 
 class _CarouselChangeReasonDemoState extends State<CarouselChangeReasonDemo> {
   String reason = '';
-  final CarouselController _controller = CarouselController();
+  final CarouselSliderController _controller = CarouselSliderController();
 
   void onPageChange(int index, CarouselPageChangedReason changeReason) {
     setState(() {

--- a/lib/carousel_controller.dart
+++ b/lib/carousel_controller.dart
@@ -23,10 +23,10 @@ abstract class CarouselSliderController {
 
   void stopAutoPlay();
 
-  factory CarouselSliderController() => CarouselControllerImpl();
+  factory CarouselSliderController() => CarouselSliderControllerImpl();
 }
 
-class CarouselControllerImpl implements CarouselSliderController {
+class CarouselSliderControllerImpl implements CarouselSliderController {
   final Completer<Null> _readyCompleter = Completer<Null>();
 
   CarouselState? _state;

--- a/lib/carousel_controller.dart
+++ b/lib/carousel_controller.dart
@@ -6,7 +6,7 @@ import 'carousel_options.dart';
 import 'carousel_state.dart';
 import 'utils.dart';
 
-abstract class CarouselController {
+abstract class CarouselSliderController {
   bool get ready;
 
   Future<Null> get onReady;
@@ -23,10 +23,10 @@ abstract class CarouselController {
 
   void stopAutoPlay();
 
-  factory CarouselController() => CarouselControllerImpl();
+  factory CarouselSliderController() => CarouselControllerImpl();
 }
 
-class CarouselControllerImpl implements CarouselController {
+class CarouselControllerImpl implements CarouselSliderController {
   final Completer<Null> _readyCompleter = Completer<Null>();
 
   CarouselState? _state;

--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -39,13 +39,13 @@ class CarouselSlider extends StatefulWidget {
       {required this.items,
       required this.options,
       this.disableGesture,
-      CarouselController? carouselController,
+      CarouselSliderController? carouselController,
       Key? key})
       : itemBuilder = null,
         itemCount = items != null ? items.length : 0,
         _carouselController = carouselController != null
             ? carouselController as CarouselControllerImpl
-            : CarouselController() as CarouselControllerImpl,
+            : CarouselSliderController() as CarouselControllerImpl,
         super(key: key);
 
   /// The on demand item builder constructor
@@ -54,12 +54,12 @@ class CarouselSlider extends StatefulWidget {
       required this.itemBuilder,
       required this.options,
       this.disableGesture,
-      CarouselController? carouselController,
+      CarouselSliderController? carouselController,
       Key? key})
       : items = null,
         _carouselController = carouselController != null
             ? carouselController as CarouselControllerImpl
-            : CarouselController() as CarouselControllerImpl,
+            : CarouselSliderController() as CarouselControllerImpl,
         super(key: key);
 
   @override
@@ -355,7 +355,7 @@ class CarouselSliderState extends State<CarouselSlider>
                 BuildContext storageContext = carouselState!
                     .pageController!.position.context.storageContext;
                 final double? previousSavedPosition =
-                    PageStorage.of(storageContext)?.readState(storageContext)
+                    PageStorage.of(storageContext).readState(storageContext)
                         as double?;
                 if (previousSavedPosition != null) {
                   itemOffset = previousSavedPosition - idx.toDouble();

--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -31,7 +31,7 @@ class CarouselSlider extends StatefulWidget {
   final ExtendedIndexedWidgetBuilder? itemBuilder;
 
   /// A [MapController], used to control the map.
-  final CarouselControllerImpl _carouselController;
+  final CarouselSliderControllerImpl _carouselController;
 
   final int? itemCount;
 
@@ -44,8 +44,8 @@ class CarouselSlider extends StatefulWidget {
       : itemBuilder = null,
         itemCount = items != null ? items.length : 0,
         _carouselController = carouselController != null
-            ? carouselController as CarouselControllerImpl
-            : CarouselSliderController() as CarouselControllerImpl,
+            ? carouselController as CarouselSliderControllerImpl
+            : CarouselSliderController() as CarouselSliderControllerImpl,
         super(key: key);
 
   /// The on demand item builder constructor
@@ -58,8 +58,8 @@ class CarouselSlider extends StatefulWidget {
       Key? key})
       : items = null,
         _carouselController = carouselController != null
-            ? carouselController as CarouselControllerImpl
-            : CarouselSliderController() as CarouselControllerImpl,
+            ? carouselController as CarouselSliderControllerImpl
+            : CarouselSliderController() as CarouselSliderControllerImpl,
         super(key: key);
 
   @override
@@ -68,7 +68,7 @@ class CarouselSlider extends StatefulWidget {
 
 class CarouselSliderState extends State<CarouselSlider>
     with TickerProviderStateMixin {
-  final CarouselControllerImpl carouselController;
+  final CarouselSliderControllerImpl carouselController;
   Timer? timer;
 
   CarouselOptions get options => widget.options;


### PR DESCRIPTION
Since Flutter v3.24.0 update, it was added a `CarouselView` widget that has its own controller named `CarouselController`.

This PR objective is to solve compatibility issues between the package and Flutter's Material package