### PR TITLE
Changes for flutter upgrade to version 3.24

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -6,7 +6,7 @@ import 'package:carousel_slider/carousel_state.dart';
 import 'package:flutter/gestures.dart';
 import 'package:flutter/material.dart';
 
-import 'carousel_controller.dart';
+import 'carousel_controller.dart' as carousel;
 import 'carousel_options.dart';
 import 'utils.dart';
 
@@ -31,7 +31,7 @@ class CarouselSlider extends StatefulWidget {
   final ExtendedIndexedWidgetBuilder? itemBuilder;
 
   /// A [MapController], used to control the map.
-  final CarouselControllerImpl _carouselController;
+  final carousel.CarouselControllerImpl _carouselController;
 
   final int? itemCount;
 
@@ -39,13 +39,13 @@ class CarouselSlider extends StatefulWidget {
       {required this.items,
       required this.options,
       this.disableGesture,
-      CarouselController? carouselController,
+      carousel.CarouselController? carouselController,
       Key? key})
       : itemBuilder = null,
         itemCount = items != null ? items.length : 0,
         _carouselController = carouselController != null
-            ? carouselController as CarouselControllerImpl
-            : CarouselController() as CarouselControllerImpl,
+            ? carouselController as carousel.CarouselControllerImpl
+            : carousel.CarouselController() as carousel.CarouselControllerImpl,
         super(key: key);
 
   /// The on demand item builder constructor
@@ -54,12 +54,12 @@ class CarouselSlider extends StatefulWidget {
       required this.itemBuilder,
       required this.options,
       this.disableGesture,
-      CarouselController? carouselController,
+      carousel.CarouselController? carouselController,
       Key? key})
       : items = null,
         _carouselController = carouselController != null
-            ? carouselController as CarouselControllerImpl
-            : CarouselController() as CarouselControllerImpl,
+            ? carouselController as carousel.CarouselControllerImpl
+            : carousel.CarouselController() as carousel.CarouselControllerImpl,
         super(key: key);
 
   @override
@@ -68,7 +68,7 @@ class CarouselSlider extends StatefulWidget {
 
 class CarouselSliderState extends State<CarouselSlider>
     with TickerProviderStateMixin {
-  final CarouselControllerImpl carouselController;
+  final carousel.CarouselControllerImpl carouselController;
   Timer? timer;
 
   CarouselOptions get options => widget.options;
@@ -355,7 +355,7 @@ class CarouselSliderState extends State<CarouselSlider>
                 BuildContext storageContext = carouselState!
                     .pageController!.position.context.storageContext;
                 final double? previousSavedPosition =
-                    PageStorage.of(storageContext)?.readState(storageContext)
+                    PageStorage.of(storageContext).readState(storageContext)
                         as double?;
                 if (previousSavedPosition != null) {
                   itemOffset = previousSavedPosition - idx.toDouble();


### PR DESCRIPTION
**Description**
While upgrading flutter to **3.24**, it was showing an error. The error was: 
CarouselController() is getting imported from 2 packages.

The reason is in this latest version, flutter has added a CarouselView() widget in material package which also has a controller named CarouselController. 
You can see the changes here: [reference](https://github.com/flutter/flutter/pull/148094/files).
Or you can know more about this [here](https://medium.com/flutter/whats-new-in-flutter-3-24-6c040f87d1e4).

Hence while building, it was showing the error.

This Fixes the Issue #457 

**Fix**:
I have used prefix for telling flutter that this CarouselController() and CarouselControllerImpl are imported from 'carousel_controller.dart' package in the file carousel_slider.dart
Also I have removed null check operator on line no. 358 in the same file. The reason is flutter have added PageStorage.maybeOf packages/flutter/test/widgets/page_storage_test.dart and now PageStorage.of(storageContext) gives non null values only, and hence that check was not needed. [commit ref](https://github.com/flutter/flutter/commit/37b72342b0ce86fbfc238a9d43e524608b89af3a#diff-ec4a7db2c8b3635f5b78c1f6f8197f897f5a1b507a0843d81995b064bfccc597)

**Testing**
Manual Testing: I have done manual testing in my project where we use this package and it was completely working fine.
