### PR TITLE
Hid CarouselController

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -4,7 +4,7 @@ import 'dart:async';
 
 import 'package:carousel_slider/carousel_state.dart';
 import 'package:flutter/gestures.dart';
-import 'package:flutter/material.dart';
+import 'package:flutter/material.dart' hide CarouselController;
 
 import 'carousel_controller.dart';
 import 'carousel_options.dart';


### PR DESCRIPTION
Fixed the following error by hiding CarouselController coming from material.dart to prevent conflict

Error Statement: 
../../../../AppData/Local/Pub/Cache/hosted/pub.dev/carousel_slider-4.2.1/lib/carousel_slider.dart:9:1: Error: 'CarouselController' is imported from both 'package:carousel_slider/carousel_controller.dart' and 'package:flutter/src/material/carousel.dart'.
