### PR TITLE
add PointerDeviceKind.stylus to dragDevices for Apple Pencil support

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -308,6 +308,7 @@ class CarouselSliderState extends State<CarouselSlider>
         dragDevices: {
           PointerDeviceKind.touch,
           PointerDeviceKind.mouse,
+          PointerDeviceKind.stylus,
         },
       ),
       clipBehavior: widget.options.clipBehavior,


### PR DESCRIPTION
- Added `PointerDeviceKind.stylus` to `dragDevices` for Apple Pencil support
- Issue link : https://github.com/serenader2014/flutter_carousel_slider/issues/390