### PR TITLE
fix: RangeError (length): Invalid value: Valid value range is empty: 0

### DIFF
--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -333,7 +333,9 @@ class CarouselSliderState extends State<CarouselSlider>
           animation: carouselState!.pageController!,
           child: (widget.items != null)
               ? (widget.items!.length > 0 ? widget.items![index] : Container())
-              : widget.itemBuilder!(context, index, idx),
+              : ((widget.itemCount ?? 0) > 0
+                  ? widget.itemBuilder!(context, index, idx)
+                  : const SizedBox.shrink()),
           builder: (BuildContext context, child) {
             double distortionValue = 1.0;
             // if `enlargeCenterPage` is true, we must calculate the carousel item's height


### PR DESCRIPTION
This PR attempts to fix [#486](https://github.com/serenader2014/flutter_carousel_slider/issues/486)