### PR TITLE
feat: add stopAutoPlayOnTouch option to CarouselSlider

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,6 +9,7 @@
 .buildlog/
 .history
 .svn/
+.serena/
 
 # IntelliJ related
 *.iml

--- a/lib/carousel_options.dart
+++ b/lib/carousel_options.dart
@@ -98,6 +98,12 @@ class CarouselOptions {
   /// Default to `true`.
   final bool pauseAutoPlayOnTouch;
 
+  /// If `true`, the auto play function will be stopped (not paused) when user is interacting with
+  /// the carousel, and will NOT be resumed when user finishes interacting.
+  /// This option takes precedence over `pauseAutoPlayOnTouch`.
+  /// Default to `false`.
+  final bool stopAutoPlayOnTouch;
+
   /// If `true`, the auto play function will be paused when user is calling
   /// pageController's `nextPage` or `previousPage` or `animateToPage` method.
   /// And after the animation complete, the auto play will be resumed.
@@ -160,6 +166,7 @@ class CarouselOptions {
     this.disableCenter = false,
     this.padEnds = true,
     this.clipBehavior = Clip.hardEdge,
+    this.stopAutoPlayOnTouch = false,
   });
 
   ///Generate new [CarouselOptions] based on old ones.
@@ -189,7 +196,8 @@ class CarouselOptions {
           double? enlargeFactor,
           bool? disableCenter,
           Clip? clipBehavior,
-          bool? padEnds}) =>
+          bool? padEnds,
+          bool? stopAutoPlayOnTouch}) =>
       CarouselOptions(
         height: height ?? this.height,
         aspectRatio: aspectRatio ?? this.aspectRatio,
@@ -219,5 +227,6 @@ class CarouselOptions {
         disableCenter: disableCenter ?? this.disableCenter,
         clipBehavior: clipBehavior ?? this.clipBehavior,
         padEnds: padEnds ?? this.padEnds,
+        stopAutoPlayOnTouch: stopAutoPlayOnTouch ?? this.stopAutoPlayOnTouch,
       );
 }

--- a/lib/carousel_slider.dart
+++ b/lib/carousel_slider.dart
@@ -279,7 +279,10 @@ class CarouselSliderState extends State<CarouselSlider>
   }
 
   void onPanDown() {
-    if (widget.options.pauseAutoPlayOnTouch) {
+    // stopAutoPlayOnTouch takes precedence over pauseAutoPlayOnTouch
+    if (widget.options.stopAutoPlayOnTouch) {
+      clearTimer();
+    } else if (widget.options.pauseAutoPlayOnTouch) {
       clearTimer();
     }
 
@@ -287,7 +290,9 @@ class CarouselSliderState extends State<CarouselSlider>
   }
 
   void onPanUp() {
-    if (widget.options.pauseAutoPlayOnTouch) {
+    // Only resume if stopAutoPlayOnTouch is false
+    // If stopAutoPlayOnTouch is true, the timer stays stopped
+    if (!widget.options.stopAutoPlayOnTouch && widget.options.pauseAutoPlayOnTouch) {
       resumeTimer();
     }
   }


### PR DESCRIPTION
## Summary

This PR adds a new option `stopAutoPlayOnTouch` to the CarouselSlider that allows users to permanently stop autoplay when they interact with the carousel, unlike `pauseAutoPlayOnTouch` which resumes after interaction.

## Changes

- Added `stopAutoPlayOnTouch` property to `CarouselOptions` (defaults to `false`)
- Implemented priority logic where `stopAutoPlayOnTouch` overrides `pauseAutoPlayOnTouch` behavior
- Updated `onPanDown()` and `onPanUp()` methods to handle stop vs pause correctly
- Added `.serena/` to `.gitignore`

## Motivation

Currently, the `pauseAutoPlayOnTouch` option pauses autoplay during user interaction but automatically resumes it when the user finishes interacting. Some use cases require permanently stopping autoplay once the user starts interacting with the carousel, giving them full control without automatic resumption.

## Implementation Details

The `stopAutoPlayOnTouch` option takes precedence over `pauseAutoPlayOnTouch`:

- When `stopAutoPlayOnTouch = true`: autoplay stops permanently on touch (no resume on pan up)
- When `stopAutoPlayOnTouch = false` and `pauseAutoPlayOnTouch = true`: existing pause/resume behavior
- When both are `false`: no autoplay interruption on touch

## Test Plan

- Flutter analyze passes with no errors
- Backward compatible (defaults to `false`)
- No breaking changes to existing API