### PR TITLE
Refactor: Replace deprecated withOpacity() with withValues() to remove warnings

### DIFF
--- a/example/lib/main.dart
+++ b/example/lib/main.dart
@@ -444,7 +444,7 @@ class _CarouselWithIndicatorState extends State<CarouselWithIndicatorDemo> {
                     color: (Theme.of(context).brightness == Brightness.dark
                             ? Colors.white
                             : Colors.black)
-                        .withOpacity(_current == entry.key ? 0.9 : 0.4)),
+                        .withValues(alpha: _current == entry.key ? 0.9 : 0.4)),
               ),
             );
           }).toList(),


### PR DESCRIPTION
This PR replaces all usages of the deprecated Color.withOpacity() API with
Color.withValues(alpha: ...) as recommended by Flutter.

Reason:
- `withOpacity()` is deprecated and triggers warnings.
- `withValues()` avoids precision loss and is the correct modern API.

Example change:
Before:
color.withOpacity(0.4)

After:
color.withValues(alpha: 0.4)
